### PR TITLE
Add orders_bundle API and use in Orders page

### DIFF
--- a/lottery/src/app/api/orders_bundle/route.js
+++ b/lottery/src/app/api/orders_bundle/route.js
@@ -1,0 +1,162 @@
+import db from '@/lib/db';
+import { authenticate } from '@/lib/auth';
+
+// Parse YYYY-MM-DD as a local date to avoid UTC skew
+function parseLocalYMD(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, (m || 1) - 1, d || 1);
+}
+
+function computeDayType(dateStr) {
+  const d = parseLocalYMD(dateStr);
+  const day = d.getDay();
+  if (day === 0) return 'SUNDAY';
+  if (day === 6) return 'SATURDAY';
+  return 'WEEKDAY';
+}
+
+// GET /api/orders_bundle?dates=YYYY-MM-DD,YYYY-MM-DD
+// Returns all data needed for Orders page in a single call.
+export async function GET(req) {
+  const auth = authenticate(req, ['samarakoonkumara@gmail.com']);
+  if (auth.error) {
+    return new Response(JSON.stringify({ error: auth.error }), { status: auth.status });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const datesParam = searchParams.get('dates') || searchParams.get('date');
+  const includeInactive = searchParams.get('includeInactive') === 'true';
+
+  if (!datesParam) {
+    return new Response(JSON.stringify({ error: 'dates parameter required' }), { status: 400 });
+  }
+
+  const dates = datesParam.split(',').map(s => s.trim()).filter(Boolean);
+  if (dates.length === 0) {
+    return new Response(JSON.stringify({ error: 'No valid dates provided' }), { status: 400 });
+  }
+
+  let conn;
+  try {
+    conn = await db.getConnection();
+
+    const [lotteryTypes] = await conn.query(
+      'SELECT id, name, category FROM lottery_types ORDER BY name'
+    );
+
+    const [defaultRows] = await conn.query(`
+      SELECT lottery_type_id, SUM(quantity) as default_quantity
+      FROM orders
+      GROUP BY lottery_type_id
+    `);
+    const defaultQuantities = {};
+    defaultRows.forEach(row => {
+      defaultQuantities[row.lottery_type_id] = row.default_quantity || 0;
+    });
+
+    const shopQuery = includeInactive
+      ? 'SELECT * FROM shops'
+      : 'SELECT * FROM shops WHERE active = TRUE';
+    const [shops] = await conn.query(shopQuery);
+
+    const [activeShops] = await conn.query('SELECT id FROM shops WHERE active = 1');
+    const activeShopIds = activeShops.map(s => s.id);
+
+    const [dateSpecificRows] = await conn.query(`
+      SELECT shop_id, lottery_id, quantity, DATE_FORMAT(date, '%Y-%m-%d') AS date
+      FROM distribution_rules
+      WHERE date IN (?)
+    `, [dates]);
+
+    const neededDayTypes = Array.from(new Set(dates.map(d => computeDayType(d))));
+    const [generalRows] = await conn.query(`
+      SELECT shop_id, lottery_id, quantity, day_type
+      FROM distribution_rules
+      WHERE date IS NULL AND day_type IN (?)
+    `, [neededDayTypes]);
+
+    const dateSpecificMap = {};
+    for (const r of dateSpecificRows) {
+      if (!dateSpecificMap[r.date]) dateSpecificMap[r.date] = {};
+      if (!dateSpecificMap[r.date][r.shop_id]) dateSpecificMap[r.date][r.shop_id] = {};
+      dateSpecificMap[r.date][r.shop_id][r.lottery_id] = r.quantity;
+    }
+
+    const generalMap = {};
+    for (const r of generalRows) {
+      if (!generalMap[r.day_type]) generalMap[r.day_type] = {};
+      if (!generalMap[r.day_type][r.shop_id]) generalMap[r.day_type][r.shop_id] = {};
+      generalMap[r.day_type][r.shop_id][r.lottery_id] = r.quantity;
+    }
+
+    const distributionTotals = { dates: {} };
+
+    for (const date of dates) {
+      const dayType = computeDayType(date);
+      const lotteryTotals = [];
+      let grandTotal = 0;
+
+      for (const lot of lotteryTypes) {
+        let total = 0;
+        for (const shopId of activeShopIds) {
+          const dateSpecQty = dateSpecificMap[date]?.[shopId]?.[lot.id];
+          if (dateSpecQty != null) {
+            total += dateSpecQty;
+          } else {
+            const genQty = generalMap[dayType]?.[shopId]?.[lot.id];
+            if (genQty != null) total += genQty;
+          }
+        }
+        grandTotal += total;
+        lotteryTotals.push({
+          lottery_id: lot.id,
+          name: lot.name,
+          category: lot.category,
+          quantity: total,
+        });
+      }
+
+      distributionTotals.dates[date] = {
+        day_type: dayType,
+        lottery_totals: lotteryTotals,
+        grand_total: grandTotal,
+      };
+    }
+
+    const fromDate = dates[0];
+    const toDate = dates[dates.length - 1];
+    const [orderingNotes] = await conn.query(
+      `
+      SELECT 
+        id,
+        shop_id,
+        DATE_FORMAT(note_date, '%Y-%m-%d') AS note_date,
+        message,
+        is_read,
+        created_at,
+        updated_at
+      FROM ordering_notes
+      WHERE note_date BETWEEN ? AND ?
+      ORDER BY note_date DESC, id DESC
+      LIMIT 200
+    `,
+      [fromDate, toDate]
+    );
+
+    return new Response(
+      JSON.stringify({
+        lotteryTypes,
+        defaultQuantities,
+        shops,
+        distributionTotals,
+        orderingNotes,
+      }),
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('GET /api/orders_bundle error:', error);
+    return new Response(JSON.stringify({ error: 'Server error' }), { status: 500 });
+  } finally {
+    if (conn) conn.release();
+  }
+}

--- a/lottery/src/app/orders/page.js
+++ b/lottery/src/app/orders/page.js
@@ -48,22 +48,49 @@ export default function Orders() {
     const [originalDates, setOriginalDates] = useState(initialDates);
     const [originalDailyOrders, setOriginalDailyOrders] = useState({});
 
+    const applyOrderingNotes = (notes) => {
+        const unreadNotes = (notes || []).filter(note => !note.is_read);
+        setOrderingNotes(unreadNotes);
+    };
+
+    const fetchOrdersBundle = async (newDates) => {
+        const validDates = newDates.filter(date => date !== '');
+        if (validDates.length === 0) return null;
+
+        try {
+            const response = await fetch(`/api/orders_bundle?dates=${validDates.join(',')}`);
+            if (!response.ok) {
+                console.error('Error fetching orders bundle:', response.statusText);
+                return null;
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Error fetching orders bundle:', error);
+            return null;
+        }
+    };
+
     // Fetch initial data on mount
     useEffect(() => {
         const fetchInitialData = async () => {
             setLoading(true);
             try {
-                const [lotteryTypesRes, defaultQuantitiesRes, shopsRes] = await Promise.all([
-                    fetch('/api/lottery_types').then(res => res.json()),
-                    fetch('/api/default_quantities').then(res => res.json()),
-                    fetch('/api/shops').then(res => res.json()),
-                ]);
-                
-                setLotteryTypes(lotteryTypesRes);
-                setDefaultQuantities(defaultQuantitiesRes);
-                setShops(shopsRes);
-    
-                await fetchDailyOrders(initialDates, lotteryTypesRes, defaultQuantitiesRes);
+                const bundle = await fetchOrdersBundle(initialDates);
+                if (!bundle) return;
+
+                setLotteryTypes(bundle.lotteryTypes || []);
+                setDefaultQuantities(bundle.defaultQuantities || {});
+                setShops(bundle.shops || []);
+
+                await fetchDailyOrders(
+                    initialDates,
+                    bundle.lotteryTypes || [],
+                    bundle.defaultQuantities || {},
+                    {
+                        distributionTotals: bundle.distributionTotals,
+                        orderingNotes: bundle.orderingNotes,
+                    }
+                );
             } catch (error) {
                 console.error('Error fetching initial data:', error);
             } finally {
@@ -114,7 +141,8 @@ export default function Orders() {
     };
 
     // Build daily orders purely from distribution totals (no existing orders lookup)
-    const fetchDailyOrders = async (newDates, lotteryTypesData, defaultQuantitiesData) => {
+    const fetchDailyOrders = async (newDates, lotteryTypesData, defaultQuantitiesData, options = {}) => {
+        const { distributionTotals, orderingNotes: preloadedNotes } = options;
         const validDates = newDates.filter(date => date !== '');
         if (validDates.length === 0) return;
 
@@ -133,7 +161,7 @@ export default function Orders() {
             });
 
             // Overlay distribution totals
-            const distTotalsRes = await fetch(`/api/distribution_totals?dates=${validDates.join(',')}`).then(r => r.ok ? r.json() : null);
+            const distTotalsRes = distributionTotals || await fetch(`/api/distribution_totals?dates=${validDates.join(',')}`).then(r => r.ok ? r.json() : null);
             console.log('Distribution Totals Response:', distTotalsRes);
             if (distTotalsRes && distTotalsRes.dates) {
                 validDates.forEach(date => {
@@ -152,7 +180,11 @@ export default function Orders() {
             setOriginalDailyOrders(JSON.parse(JSON.stringify(initialDailyOrders)));
 
             // Fetch ordering notes for these dates
-            await fetchOrderingNotes(validDates);
+            if (preloadedNotes) {
+                applyOrderingNotes(preloadedNotes);
+            } else {
+                await fetchOrderingNotes(validDates);
+            }
         } catch (error) {
             console.error('Error building orders from distribution totals:', error);
         } finally {
@@ -172,9 +204,7 @@ export default function Orders() {
             
             if (response.ok) {
                 const notes = await response.json();
-                // Filter for unread notes only
-                const unreadNotes = notes.filter(note => !note.is_read);
-                setOrderingNotes(unreadNotes);
+                applyOrderingNotes(notes);
             }
         } catch (error) {
             console.error('Error fetching ordering notes:', error);
@@ -215,7 +245,7 @@ export default function Orders() {
     };
 
     // Handle date change for Day 1 (auto-sets Days 2 and 3)
-    const handleDateChange = (index, value) => {
+    const handleDateChange = async (index, value) => {
         const newDates = [...dates];
         newDates[index] = value;
         if (index === 0 && value) {
@@ -227,8 +257,19 @@ export default function Orders() {
         
         // Clear existing notes when dates change
         setOrderingNotes([]);
-        
-        fetchDailyOrders(newDates, lotteryTypes, defaultQuantities);
+
+        const bundle = await fetchOrdersBundle(newDates);
+        if (bundle) {
+            if (bundle.lotteryTypes) setLotteryTypes(bundle.lotteryTypes);
+            if (bundle.defaultQuantities) setDefaultQuantities(bundle.defaultQuantities);
+            if (bundle.shops) setShops(bundle.shops);
+            await fetchDailyOrders(newDates, bundle.lotteryTypes || lotteryTypes, bundle.defaultQuantities || defaultQuantities, {
+                distributionTotals: bundle.distributionTotals,
+                orderingNotes: bundle.orderingNotes,
+            });
+        } else {
+            fetchDailyOrders(newDates, lotteryTypes, defaultQuantities);
+        }
     };
 
     // Toggle edit mode


### PR DESCRIPTION
Introduce a new /api/orders_bundle endpoint that aggregates lottery types, default quantities, shops, distribution totals (per date), and ordering notes in a single call to reduce client round-trips. Update Orders page to call fetchOrdersBundle, apply preloaded ordering notes, and pass bundled distributionTotals into fetchDailyOrders. Adjust fetchDailyOrders signature to accept preloaded data, add applyOrderingNotes helper, and make handleDateChange async to fetch and apply the bundle when dates change. This streamlines initial load and date-change flows and avoids duplicate network requests for distribution totals and notes.