### PR TITLE
Add Redis caching and cache invalidation

### DIFF
--- a/lottery/package-lock.json
+++ b/lottery/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
+        "redis": "^6.0.0",
         "serverless-mysql": "^2.1.0"
       },
       "devDependencies": {
@@ -917,6 +918,78 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.0.0.tgz",
+      "integrity": "sha512-P0n5NkV9IIdT6nYXOfMHG83sho8pE7Nay7yw27wOGVLv4DthgvzebpGz6m7VuMTizeJmw3LPw2Xek5wFUhGpVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.0.tgz",
+      "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.0.0.tgz",
+      "integrity": "sha512-F+eqFfgPcy57Zs1KW7UtLnBtRk6lxAUIoe7dyZerpm6e+ssYXG/dWJrbrHFYs0b7tt6QBtYpVuukBuM9XqhUAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.0.0.tgz",
+      "integrity": "sha512-VHuCJ2W0YWFixGZh/l//8JiyOsD4gN+NhjdRAGIoUe0UQ4mtq1NyY2ZJ973XT+vYhaU21XdK8r8oNrd5n7wbzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.0.0.tgz",
+      "integrity": "sha512-QWhkYsg+3lhBrBf+cbzybtV8LQcSrk7iXIgTaGU+pHNFTkql7TpVRE24ROS6M2ybVIV6O/zxTqfxgxxYiqyw0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -2101,6 +2174,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5089,6 +5171,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/redis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.0.0.tgz",
+      "integrity": "sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "6.0.0",
+        "@redis/client": "6.0.0",
+        "@redis/json": "6.0.0",
+        "@redis/search": "6.0.0",
+        "@redis/time-series": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/lottery/package.json
+++ b/lottery/package.json
@@ -19,6 +19,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
+    "redis": "^6.0.0",
     "serverless-mysql": "^2.1.0"
   },
   "devDependencies": {

--- a/lottery/src/app/api/default_quantities/route.js
+++ b/lottery/src/app/api/default_quantities/route.js
@@ -1,5 +1,7 @@
 import db from '@/lib/db';
 import { authenticate } from '@/lib/auth';
+import redis from '@/lib/redis';
+
 export async function GET(req) {
     
     const auth = authenticate(req,['samarakoonkumara@gmail.com']);
@@ -9,7 +11,18 @@ export async function GET(req) {
         { status: auth.status }
       );
     }
+
     try {
+        const cacheKey = 'cache:default_quantities';
+        const cachedData = await redis.get(cacheKey);
+
+        if (cachedData) {
+            return new Response(cachedData, {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
         const [rows] = await db.query(`
             SELECT lottery_type_id, SUM(quantity) as default_quantity
             FROM orders
@@ -19,7 +32,15 @@ export async function GET(req) {
         rows.forEach(row => {
             defaultQuantities[row.lottery_type_id] = row.default_quantity || 0;
         });
-        return new Response(JSON.stringify(defaultQuantities), { status: 200 });
+
+        const responseJson = JSON.stringify(defaultQuantities);
+        // Cache for 1 hour
+        await redis.set(cacheKey, responseJson, { EX: 3600 });
+
+        return new Response(responseJson, { 
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+        });
     } catch (error) {
         return new Response(JSON.stringify({ error: 'Server error' }), { status: 500 });
     }

--- a/lottery/src/app/api/lottery_types/route.js
+++ b/lottery/src/app/api/lottery_types/route.js
@@ -1,5 +1,6 @@
 import db from '@/lib/db';
 import { authenticate } from '@/lib/auth';
+import redis from '@/lib/redis';
 
 export async function GET(req) {
   const auth = authenticate(req,['samarakoonkumara@gmail.com']);
@@ -11,11 +12,29 @@ export async function GET(req) {
   }
 
   try {
+    const cacheKey = 'cache:lottery_types';
+    const cachedData = await redis.get(cacheKey);
+
+    if (cachedData) {
+      return new Response(cachedData, { 
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     // db.query() returns [rows, fields]
     const [lotteryTypes] = await db.query('SELECT * FROM lottery_types');
-    return new Response(JSON.stringify(lotteryTypes), { status: 200 });
+    const responseJson = JSON.stringify(lotteryTypes);
+
+    // Cache for 24 hours (86400 seconds)
+    await redis.set(cacheKey, responseJson, { EX: 86400 });
+
+    return new Response(responseJson, { 
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
   } catch (error) {
-    console.error('GET /api/shops error:', error);
+    console.error('GET /api/lottery_types error:', error);
     return new Response(JSON.stringify({ error: 'Server error' }), { status: 500 });
   }
 }

--- a/lottery/src/app/api/orders/route.js
+++ b/lottery/src/app/api/orders/route.js
@@ -1,5 +1,6 @@
 import db from '@/lib/db';
 import { authenticate } from '@/lib/auth';
+import redis from '@/lib/redis';
 
 export async function GET(req) {
   const auth = authenticate(req,['samarakoonkumara@gmail.com']);
@@ -47,6 +48,10 @@ export async function POST(req) {
     );
 
     await conn.commit();
+
+    // Invalidate default quantities cache since they are aggregates of orders
+    await redis.del('cache:default_quantities');
+
     return new Response(JSON.stringify({ message: 'Orders updated' }), { status: 200 });
   } catch (error) {
     if (conn) {

--- a/lottery/src/app/api/orders_bundle/route.js
+++ b/lottery/src/app/api/orders_bundle/route.js
@@ -1,5 +1,6 @@
 import db from '@/lib/db';
 import { authenticate } from '@/lib/auth';
+import redis from '@/lib/redis';
 
 // Parse YYYY-MM-DD as a local date to avoid UTC skew
 function parseLocalYMD(dateStr) {
@@ -40,27 +41,48 @@ export async function GET(req) {
   try {
     conn = await db.getConnection();
 
-    const [lotteryTypes] = await conn.query(
-      'SELECT id, name, category FROM lottery_types ORDER BY name'
-    );
+    // Check Redis for Lottery Types
+    let lotteryTypes = await redis.get('cache:lottery_types');
+    if (lotteryTypes) {
+      lotteryTypes = JSON.parse(lotteryTypes);
+    } else {
+      [lotteryTypes] = await conn.query('SELECT id, name, category FROM lottery_types ORDER BY name');
+      await redis.set('cache:lottery_types', JSON.stringify(lotteryTypes), { EX: 86400 });
+    }
 
-    const [defaultRows] = await conn.query(`
-      SELECT lottery_type_id, SUM(quantity) as default_quantity
-      FROM orders
-      GROUP BY lottery_type_id
-    `);
-    const defaultQuantities = {};
-    defaultRows.forEach(row => {
-      defaultQuantities[row.lottery_type_id] = row.default_quantity || 0;
-    });
+    // Check Redis for Default Quantities
+    let defaultQuantities = await redis.get('cache:default_quantities');
+    if (defaultQuantities) {
+      defaultQuantities = JSON.parse(defaultQuantities);
+    } else {
+      const [defaultRows] = await conn.query(`
+        SELECT lottery_type_id, SUM(quantity) as default_quantity
+        FROM orders
+        GROUP BY lottery_type_id
+      `);
+      defaultQuantities = {};
+      defaultRows.forEach(row => {
+        defaultQuantities[row.lottery_type_id] = row.default_quantity || 0;
+      });
+      await redis.set('cache:default_quantities', JSON.stringify(defaultQuantities), { EX: 3600 });
+    }
 
-    const shopQuery = includeInactive
-      ? 'SELECT * FROM shops'
-      : 'SELECT * FROM shops WHERE active = TRUE';
-    const [shops] = await conn.query(shopQuery);
+    // Check Redis for Shops
+    const shopCacheKey = includeInactive ? 'cache:shops:all' : 'cache:shops:active';
+    let shops = await redis.get(shopCacheKey);
+    if (shops) {
+      shops = JSON.parse(shops);
+    } else {
+      const shopQuery = includeInactive
+        ? 'SELECT * FROM shops'
+        : 'SELECT * FROM shops WHERE active = TRUE';
+      [shops] = await conn.query(shopQuery);
+      await redis.set(shopCacheKey, JSON.stringify(shops), { EX: 86400 });
+    }
 
-    const [activeShops] = await conn.query('SELECT id FROM shops WHERE active = 1');
-    const activeShopIds = activeShops.map(s => s.id);
+    // To compute distribution logic, we need active shops IDs.
+    // If we included inactive shops, filter for active ones. If not, map all.
+    const activeShopIds = shops.filter(s => s.active || s.active === 1).map(s => s.id);
 
     const [dateSpecificRows] = await conn.query(`
       SELECT shop_id, lottery_id, quantity, DATE_FORMAT(date, '%Y-%m-%d') AS date

--- a/lottery/src/app/api/shops/add/route.js
+++ b/lottery/src/app/api/shops/add/route.js
@@ -1,5 +1,6 @@
 import db from '@/lib/db';
 import { authenticate } from '@/lib/auth';
+import redis from '@/lib/redis';
 
 export async function POST(req) {
   const auth = authenticate(req,['samarakoonkumara@gmail.com']);
@@ -17,6 +18,10 @@ export async function POST(req) {
       'INSERT INTO shops (name, contact_number, address, active) VALUES (?, ?, ?, TRUE)',
       [name, contact_number, address]
     );
+
+    // Invalidate caches
+    await redis.del(['cache:shops:active', 'cache:shops:all']);
+
     return new Response(
       JSON.stringify({ message: 'Shop added successfully' }),
       { status: 201 }

--- a/lottery/src/app/api/shops/route.js
+++ b/lottery/src/app/api/shops/route.js
@@ -1,5 +1,6 @@
 import db from '@/lib/db';
 import { authenticate } from '@/lib/auth';
+import redis from '@/lib/redis';
 
 export async function GET(req) {
   const auth = authenticate(req,['samarakoonkumara@gmail.com']);
@@ -15,12 +16,30 @@ export async function GET(req) {
     const { searchParams } = new URL(req.url);
     const includeInactive = searchParams.get('includeInactive') === 'true';
 
+    const cacheKey = includeInactive ? 'cache:shops:all' : 'cache:shops:active';
+    const cachedShops = await redis.get(cacheKey);
+
+    if (cachedShops) {
+      return new Response(cachedShops, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     const query = includeInactive 
       ? 'SELECT * FROM shops'
       : 'SELECT * FROM shops WHERE active = TRUE';
 
     const [shops] = await db.query(query);
-    return new Response(JSON.stringify(shops), { status: 200 });
+    const shopsJson = JSON.stringify(shops);
+
+    // Cache for 24 hours (86400 seconds)
+    await redis.set(cacheKey, shopsJson, { EX: 86400 });
+
+    return new Response(shopsJson, { 
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
   } catch (error) {
     console.error('GET /api/shops error:', error);
     return new Response(
@@ -43,6 +62,10 @@ export async function DELETE(req) {
     const { id } = await req.json();
     // Instead of deleting, update the active status
     await db.query('UPDATE shops SET active = FALSE WHERE id = ?', [id]);
+
+    // Invalidate caches
+    await redis.del(['cache:shops:active', 'cache:shops:all']);
+
     return new Response(
       JSON.stringify({ message: 'Shop deactivated successfully' }), 
       { status: 200 }
@@ -69,6 +92,10 @@ export async function PATCH(req) {
   try {
     const { id, active } = await req.json();
     await db.query('UPDATE shops SET active = ? WHERE id = ?', [active, id]);
+    
+    // Invalidate caches
+    await redis.del(['cache:shops:active', 'cache:shops:all']);
+
     return new Response(
       JSON.stringify({ 
         message: active ? 'Shop activated successfully' : 'Shop deactivated successfully' 
@@ -114,6 +141,9 @@ export async function PUT(req) {
        WHERE id = ?`,
       [name ?? null, contact_number ?? null, address ?? null, id]
     );
+
+    // Invalidate caches
+    await redis.del(['cache:shops:active', 'cache:shops:all']);
 
     return new Response(
       JSON.stringify({ message: 'Shop updated successfully' }),

--- a/lottery/src/lib/redis.js
+++ b/lottery/src/lib/redis.js
@@ -1,0 +1,26 @@
+import { createClient } from 'redis';
+
+const globalForRedis = global || globalThis;
+
+const redisClient =
+  globalForRedis.redis ||
+  createClient({
+    username: process.env.REDIS_USERNAME || 'default',
+    password: process.env.REDIS_PASSWORD || '',
+    socket: {
+      host: process.env.REDIS_HOST || 'localhost',
+      port: process.env.REDIS_PORT ? parseInt(process.env.REDIS_PORT) : 6379,
+    },
+  });
+
+if (!globalForRedis.redis) {
+  redisClient.on('error', (err) => console.log('Redis Client Error', err));
+  
+  // Connect to Redis
+  redisClient.connect().catch(console.error);
+  
+  // Save to global context for development
+  globalForRedis.redis = redisClient;
+}
+
+export default redisClient;


### PR DESCRIPTION
Introduce a Redis client and use it to cache DB-heavy endpoints to improve performance. Adds src/lib/redis.js (singleton client using REDIS_* env vars) and the redis dependency in package.json. Integrates caching and JSON responses for /api/shops, /api/lottery_types, and /api/default_quantities (TTL: 24h for shops/lottery_types, 1h for default quantities), reads from cache when available, and caches DB results. Adds cache invalidation on shop create/update/delete and when orders are updated; also updates orders_bundle to read/write those caches. Minor error log fix for lottery_types endpoint.